### PR TITLE
Update license to valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saasquatch-cli",
   "description": "Command Line (CLI) for Referral SaaSquatch api",
   "version": "1.1.5",
-  "license": "APACHE",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "http://github.com/saasquatch/saasquatch-cli.git"


### PR DESCRIPTION
Fixes this warning on `npm install`:

``` bash
$ npm install
npm WARN package.json saasquatch-cli@1.1.5 license should be a valid SPDX license expression
```
